### PR TITLE
webp configuration added to our-img

### DIFF
--- a/Our.Umbraco.TagHelpers/Configuration/OurUmbracoTagHelpersConfiguration.cs
+++ b/Our.Umbraco.TagHelpers/Configuration/OurUmbracoTagHelpersConfiguration.cs
@@ -6,7 +6,7 @@ namespace Our.Umbraco.TagHelpers.Configuration
     {
         public InlineSvgTagHelperConfiguration OurSVG { get; set; } = new InlineSvgTagHelperConfiguration();
         public ImgTagHelperConfiguration OurImg { get; set; } = new ImgTagHelperConfiguration();
-
+    
         public SelfHostTagHelperConfiguration OurSelfHost { get; set; } = new SelfHostTagHelperConfiguration();
     }
 
@@ -50,6 +50,11 @@ namespace Our.Umbraco.TagHelpers.Configuration
         /// The property alias of the media type containing the alternative text value.
         /// </summary>
         public string AlternativeTextMediaTypePropertyAlias { get; set; } = "alternativeText";
+
+        /// <summary>
+        /// Whether images should be served with WebP sources. Defaults to true.
+        /// </summary>
+        public bool UseWebP { get; set; } = true;
     }
     public class MediaQuerySizes
     {

--- a/Our.Umbraco.TagHelpers/ImgTagHelper.cs
+++ b/Our.Umbraco.TagHelpers/ImgTagHelper.cs
@@ -183,6 +183,7 @@ namespace Our.Umbraco.TagHelpers
             var jsLazyLoad = !_globalSettings.OurImg.UseNativeLazyLoading && !AboveTheFold;
             var style = ImgStyle;
             var hasLqip = _globalSettings.OurImg.LazyLoadPlaceholder.Equals(ImagePlaceholderType.LowQualityImage);
+            var useWebP = _globalSettings.OurImg.UseWebP.Equals(true);
 
             if (MediaItem is not null)
             {
@@ -359,7 +360,7 @@ namespace Our.Umbraco.TagHelpers
 
             // Only render a WebP alternative if the image is a JPEG or PNG
             var imageFormat = MediaItem != null ? Path.GetExtension(MediaItem.Url()) : Path.GetExtension(FileSource)?.ToLower();
-            var renderWebP = imageFormat == ".jpg" || imageFormat == ".jpeg" || imageFormat == ".png";
+            var renderWebP = useWebP && (imageFormat == ".jpg" || imageFormat == ".jpeg" || imageFormat == ".png");
 
             if (imageSizes?.Any() == true)
             {

--- a/README.md
+++ b/README.md
@@ -555,6 +555,7 @@ Applying any of the below configurations within your `appsettings.json` file wil
             "DesktopXXLarge": 2200
           },
           "UseNativeLazyLoading": true, // If enabled, loading="true" is used. If disabled, the 'src' property is replaced with 'data-src' which most lazy loading JavaScript libraries will interpret and lazy load the image.
+          "UseWebP": true, // Whether images should be served with WebP sources. Defaults to true.
           "LazyLoadCssClass": "lazyload", // If 'UseNativeLazyLoading' is disabled, the class property is given an additional class for JavaScript libraries to target. Note: 'lazyload' is used by the lazysizes library.
           "LazyLoadPlaceholder": "SVG", // If 'UseNativeLazyLoading' is disabled, the 'src' property is given either an empty SVG (if value is "SVG") or a lower quality version of the original image is used (if value is "LowQualityImage")
           "LazyLoadPlaceholderLowQualityImageQuality": 5, // If 'UseNativeLazyLoading' is disabled and 'LazyLoadPlaceholder' is "LowQualityImage", what image quality should be rendered. Numeric values 1-100 accepted.


### PR DESCRIPTION
- The new `UseWebP` property can be optionally provided in **AppSettings**. It defaults to true to keep the same behavior as before.
- Checks for `UseWebP` **AND** file type before proceeding.

It's worth noting that the WebP change does not affect images with 0 sizes provided. This results in an `<IMG>` tag and no WebP extension. This behavior remains unchanged.