### PR TITLE
Reduce database queries

### DIFF
--- a/Our.Umbraco.TagHelpers/ImgTagHelper.cs
+++ b/Our.Umbraco.TagHelpers/ImgTagHelper.cs
@@ -16,7 +16,6 @@ using System.Linq;
 using System.Text;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
-using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
 using static Umbraco.Cms.Core.Constants;
 
@@ -28,10 +27,9 @@ namespace Our.Umbraco.TagHelpers
     /// & image quality (for non-media items, but still on the file system)
     /// </summary>
     [HtmlTargetElement("our-img")]
-    public class ImgTagHelper(IOptions<OurUmbracoTagHelpersConfiguration> globalSettings, IMediaService mediaService) : TagHelper
+    public class ImgTagHelper(IOptions<OurUmbracoTagHelpersConfiguration> globalSettings) : TagHelper
     {
         private OurUmbracoTagHelpersConfiguration _globalSettings = globalSettings.Value;
-        private IMediaService _mediaService = mediaService;
 
         /// <summary>
         /// A filepath to an image on disk such as /assets/image.jpg, external URL's can also be used with limited functionality

--- a/Our.Umbraco.TagHelpers/ImgTagHelper.cs
+++ b/Our.Umbraco.TagHelpers/ImgTagHelper.cs
@@ -18,6 +18,7 @@ using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
+using static Umbraco.Cms.Core.Constants;
 
 namespace Our.Umbraco.TagHelpers
 {
@@ -209,9 +210,9 @@ namespace Our.Umbraco.TagHelpers
             if (MediaItem is not null)
             {
                 #region Opting to use a media-item as the source image
-                var media = _mediaService.GetById(MediaItem.Id); // Get the media object from the media library service
-                var originalWidth = media.GetValue<double>("umbracoWidth"); // Determine the width from the originally uploaded image
-                var originalHeight = media.GetValue<double>("umbracoHeight"); // Determine the height from the originally uploaded image
+                var originalWidth = MediaItem.Value<int>(Conventions.Media.Width);
+                var originalHeight = MediaItem.Value<int>(Conventions.Media.Height);
+
                 width = ImgWidth > 0 ? ImgWidth : originalWidth; // If the element wasn't provided with a width property, use the width from the media object instead
 
                 if (!string.IsNullOrEmpty(ImgCropAlias))
@@ -250,7 +251,11 @@ namespace Our.Umbraco.TagHelpers
                             // Generate a low quality placeholder image if configured to do so
                             placeholderImgSrc = MediaItem.GetCropUrl(width: (int)width, quality: _globalSettings.OurImg.LazyLoadPlaceholderLowQualityImageQuality);
                         }
-                        height = originalHeight / originalWidth * width;
+
+                        if (originalHeight != 0)
+                        {
+                            height = originalHeight / originalWidth * width;
+                        }
                     }
                 }
 


### PR DESCRIPTION
`our-img` tag helper is executing a database query each time it's used due to using `IMediaService` to fetch the media item. Upon inspection this call is redundant as the properties (`umbracoHeight` and `umbracoWidth`) can be accessed via the `MediaItem` that is passed in as a parameter.

This change did result in a divide by zero exception occuring, which was a bit of a head scratcher as fetching the height & width via the media service also resulted in dividing by zero however no exception was thrown. Added some code to prevent a divide by zero occuring when the image height isn't known (which is typically the case for SVG files).