### PR TITLE
Prevent image upscaling (width & height) and fix crop-alias aspect ratio

### DIFF
--- a/Our.Umbraco.TagHelpers/ImgTagHelper.cs
+++ b/Our.Umbraco.TagHelpers/ImgTagHelper.cs
@@ -229,24 +229,24 @@ namespace Our.Umbraco.TagHelpers
                         // Generate a low quality placeholder image if configured to do so
                         placeholderImgSrc = MediaItem.GetCropUrl(width: (int)width, cropAlias: ImgCropAlias, quality: _globalSettings.OurImg.LazyLoadPlaceholderLowQualityImageQuality);
                     }
-                    height = cropHeight / cropWidth * width;
+                    height = StringUtils.GetDouble(cropHeight) / StringUtils.GetDouble(cropWidth) * width;
                 }
                 else
                 {
                     if (ImgHeight > 0)
                     {
-                        // If the width was capped to avoid upscaling, scale the height by the same ratio so the requested aspect ratio is preserved (instead of upscaling the height).
-                        var targetHeight = ImgWidth > 0 && width < ImgWidth
-                            ? (int)Math.Round(ImgHeight * (width / ImgWidth))
-                            : ImgHeight;
+                        // Scale the requested width & height down together so neither exceeds the source image, preserving the requested aspect ratio instead of upscaling either dimension.
+                        var requestedWidth = ImgWidth > 0 ? ImgWidth : (int)width;
+                        (var fitWidth, var fitHeight) = GetNonUpscaledSize(requestedWidth, ImgHeight, originalWidth, originalHeight);
+                        width = fitWidth;
+                        height = fitHeight;
 
-                        imgSrc = MediaItem.GetCropUrl(width: (int)width, height: targetHeight);
+                        imgSrc = MediaItem.GetCropUrl(width: (int)width, height: (int)height);
                         if (hasLqip)
                         {
                             // Generate a low quality placeholder image if configured to do so
-                            placeholderImgSrc = MediaItem.GetCropUrl(width: (int)width, height: targetHeight, quality: _globalSettings.OurImg.LazyLoadPlaceholderLowQualityImageQuality);
+                            placeholderImgSrc = MediaItem.GetCropUrl(width: (int)width, height: (int)height, quality: _globalSettings.OurImg.LazyLoadPlaceholderLowQualityImageQuality);
                         }
-                        height = targetHeight;
                     }
                     else
                     {
@@ -450,7 +450,8 @@ namespace Our.Umbraco.TagHelpers
                                 {
                                     if (size.ImageHeight > 0)
                                     {
-                                        sb.AppendLine($"<source {(jsLazyLoad ? "data-" : "")}srcset=\"{MediaItem.GetCropUrl(width: size.ImageWidth, height: size.ImageHeight, furtherOptions: "&format=webp")}\" {(_globalSettings.OurImg.MobileFirst ? $"{(minWidth > 0 ? $"media=\"(min-width: {minWidth}px)\"" : "" )}" : $"{(minWidth > 0 ? $"media=\"(max-width: {minWidth - 1}px)\"" : "" )}")} type=\"image/webp\" />");
+                                        (var variantWidth, var variantHeight) = GetNonUpscaledSize(size.ImageWidth, size.ImageHeight, originalWidth, originalHeight);
+                                        sb.AppendLine($"<source {(jsLazyLoad ? "data-" : "")}srcset=\"{MediaItem.GetCropUrl(width: variantWidth, height: variantHeight, furtherOptions: "&format=webp")}\" {(_globalSettings.OurImg.MobileFirst ? $"{(minWidth > 0 ? $"media=\"(min-width: {minWidth}px)\"" : "" )}" : $"{(minWidth > 0 ? $"media=\"(max-width: {minWidth - 1}px)\"" : "" )}")} type=\"image/webp\" />");
                                     }
                                     else
                                     {
@@ -516,7 +517,8 @@ namespace Our.Umbraco.TagHelpers
                             {
                                 if (size.ImageHeight > 0)
                                 {
-                                    sb.AppendLine($"<source {(jsLazyLoad ? "data-" : "")}srcset=\"{MediaItem.GetCropUrl(width: size.ImageWidth, height: size.ImageHeight)}\" {(_globalSettings.OurImg.MobileFirst ? $"{(minWidth > 0 ? $"media=\"(min-width: {minWidth}px)\"" : "" )}" : $"{(minWidth > 0 ? $"media=\"(max-width: {minWidth - 1}px)\"" : "" )}")} />");
+                                    (var variantWidth, var variantHeight) = GetNonUpscaledSize(size.ImageWidth, size.ImageHeight, originalWidth, originalHeight);
+                                    sb.AppendLine($"<source {(jsLazyLoad ? "data-" : "")}srcset=\"{MediaItem.GetCropUrl(width: variantWidth, height: variantHeight)}\" {(_globalSettings.OurImg.MobileFirst ? $"{(minWidth > 0 ? $"media=\"(min-width: {minWidth}px)\"" : "" )}" : $"{(minWidth > 0 ? $"media=\"(max-width: {minWidth - 1}px)\"" : "" )}")} />");
                                 }
                                 else
                                 {
@@ -541,6 +543,27 @@ namespace Our.Umbraco.TagHelpers
         }
 
         #region Private Methods
+        /// <summary>
+        /// Scales a requested width &amp; height down uniformly so neither dimension exceeds the source image, preserving the requested aspect ratio.
+        /// This prevents the image processor from upscaling. A dimension is only constrained when both it and its original counterpart are known (> 0),
+        /// so missing media dimensions (e.g. 0) simply leave that axis unconstrained.
+        /// </summary>
+        private static (int Width, int Height) GetNonUpscaledSize(int requestedWidth, int requestedHeight, int originalWidth, int originalHeight)
+        {
+            var scale = 1d;
+
+            if (requestedWidth > 0 && originalWidth > 0 && requestedWidth > originalWidth)
+            {
+                scale = Math.Min(scale, (double)originalWidth / requestedWidth);
+            }
+
+            if (requestedHeight > 0 && originalHeight > 0 && requestedHeight > originalHeight)
+            {
+                scale = Math.Min(scale, (double)originalHeight / requestedHeight);
+            }
+
+            return ((int)Math.Round(requestedWidth * scale), (int)Math.Round(requestedHeight * scale));
+        }
         private string GetImageAltText(IPublishedContent image)
         {
             try

--- a/Our.Umbraco.TagHelpers/ImgTagHelper.cs
+++ b/Our.Umbraco.TagHelpers/ImgTagHelper.cs
@@ -422,8 +422,6 @@ namespace Our.Umbraco.TagHelpers
                             _ => 0
                         };
 
-                        double sourceHeight = 0;
-
                         if (MediaItem != null)
                         {
                             #region Configure crops which can be set at variant level or inherit from the crop alias defined on the main img element itself. If neither have a crop alias, then don't use crops.
@@ -440,7 +438,6 @@ namespace Our.Umbraco.TagHelpers
                                 var cropHeight = MediaItem.LocalCrops.GetCrop(cropAlias).Height;
                                 if (size.ImageWidth <= cropWidth)
                                 {
-                                    sourceHeight = StringUtils.GetDouble(cropHeight) / StringUtils.GetDouble(cropWidth) * size.ImageWidth;
                                     sb.AppendLine($"<source {(jsLazyLoad ? "data-" : "")}srcset=\"{MediaItem.GetCropUrl(width: size.ImageWidth, cropAlias: cropAlias, furtherOptions: "&format=webp")}\" {(_globalSettings.OurImg.MobileFirst ? $"{(minWidth > 0 ? $"media=\"(min-width: {minWidth}px)\"" : "" )}" : $"{(minWidth > 0 ? $"media=\"(max-width: {minWidth - 1}px)\"" : "" )}")} type=\"image/webp\" />");
                                 }
                             }
@@ -463,7 +460,6 @@ namespace Our.Umbraco.TagHelpers
 
                         if (!string.IsNullOrEmpty(FileSource) && ImgWidth > 0 && ImgHeight > 0)
                         {
-                            sourceHeight = size.ImageHeight > 0 ? size.ImageHeight : ImgHeight / ImgWidth * size.ImageWidth;
                             var sourceUrl = AddQueryToUrl(FileSource, "width", size.ImageWidth.ToString()) + "&height=" + size.ImageHeight + "&format=webp";
                             sb.AppendLine($"<source {(jsLazyLoad ? "data-" : "")}srcset=\"{sourceUrl}\" {(_globalSettings.OurImg.MobileFirst ? $"{(minWidth > 0 ? $"media=\"(min-width: {minWidth}px)\"" : "" )}" : $"{(minWidth > 0 ? $"media=\"(max-width: {minWidth - 1}px)\"" : "" )}")} type=\"image/webp\" />");
                         }
@@ -489,8 +485,6 @@ namespace Our.Umbraco.TagHelpers
                         _ => 0
                     };
 
-                    double sourceHeight = 0;
-
                     if (MediaItem != null)
                     {
                         #region Configure crops which can be set at variant level or inherit from the crop alias defined on the main img element itself. If neither have a crop alias, then don't use crops.
@@ -507,7 +501,6 @@ namespace Our.Umbraco.TagHelpers
                             var cropHeight = MediaItem.LocalCrops.GetCrop(cropAlias).Height;
                             if (size.ImageWidth <= cropWidth)
                             {
-                                sourceHeight = StringUtils.GetDouble(cropHeight) / StringUtils.GetDouble(cropWidth) * size.ImageWidth;
                                 sb.AppendLine($"<source {(jsLazyLoad ? "data-" : "")}srcset=\"{MediaItem.GetCropUrl(width: size.ImageWidth, cropAlias: cropAlias)}\" {(_globalSettings.OurImg.MobileFirst ? $"{(minWidth > 0 ? $"media=\"(min-width: {minWidth}px)\"" : "" )}" : $"{(minWidth > 0 ? $"media=\"(max-width: {minWidth - 1}px)\"" : "" )}")} />");
                             }
                         }
@@ -530,7 +523,6 @@ namespace Our.Umbraco.TagHelpers
 
                     if (!string.IsNullOrEmpty(FileSource) && ImgWidth > 0 && ImgHeight > 0)
                     {
-                        sourceHeight = size.ImageHeight > 0 ? size.ImageHeight : ImgHeight / ImgWidth * size.ImageWidth;
                         var sourceUrl = AddQueryToUrl(FileSource, "width", size.ImageWidth.ToString()) + "&height=" + size.ImageHeight;
                         sb.AppendLine($"<source {(jsLazyLoad ? "data-" : "")}srcset=\"{sourceUrl}\" {(_globalSettings.OurImg.MobileFirst ? $"{(minWidth > 0 ? $"media=\"(min-width: {minWidth}px)\"" : "" )}" : $"{(minWidth > 0 ? $"media=\"(max-width: {minWidth - 1}px)\"" : "" )}")} />");
                     }

--- a/Our.Umbraco.TagHelpers/ImgTagHelper.cs
+++ b/Our.Umbraco.TagHelpers/ImgTagHelper.cs
@@ -235,13 +235,18 @@ namespace Our.Umbraco.TagHelpers
                 {
                     if (ImgHeight > 0)
                     {
-                        imgSrc = MediaItem.GetCropUrl(width: (int)width, height: (int)ImgHeight);
+                        // If the width was capped to avoid upscaling, scale the height by the same ratio so the requested aspect ratio is preserved (instead of upscaling the height).
+                        var targetHeight = ImgWidth > 0 && width < ImgWidth
+                            ? (int)Math.Round(ImgHeight * (width / ImgWidth))
+                            : ImgHeight;
+
+                        imgSrc = MediaItem.GetCropUrl(width: (int)width, height: targetHeight);
                         if (hasLqip)
                         {
                             // Generate a low quality placeholder image if configured to do so
-                            placeholderImgSrc = MediaItem.GetCropUrl(width: (int)width, height: (int)ImgHeight, quality: _globalSettings.OurImg.LazyLoadPlaceholderLowQualityImageQuality);
+                            placeholderImgSrc = MediaItem.GetCropUrl(width: (int)width, height: targetHeight, quality: _globalSettings.OurImg.LazyLoadPlaceholderLowQualityImageQuality);
                         }
-                        height = ImgHeight != 0 ? ImgHeight : originalHeight / originalWidth * width;
+                        height = targetHeight;
                     }
                     else
                     {


### PR DESCRIPTION
## Summary

Follow-up to the "Avoid upscaling" change (commit `7a31c07`). That change capped the requested `width` to the source image's original width, but left `height` (and the responsive `<source>` variants) unguarded, so images could still be upscaled vertically and have their aspect ratio distorted.

Example: an `our-img width="1280" height="720"` against an 800×450 source produced an **800×720** crop instead of the correct **800×450** (16:9) — width refused to upscale but height did.

## What changed

- **New shared helper `GetNonUpscaledSize`** scales a requested width/height down *uniformly* so neither dimension exceeds the source image, preserving the requested aspect ratio. A dimension is only constrained when both it and its original counterpart are known (`> 0`), so missing media dimensions leave that axis unconstrained.
- Applied to:
  - the main `<img>` src (`MediaItem` + `height` path),
  - the WebP responsive `<source>` variants,
  - the fallback responsive `<source>` variants.
  
  These last two previously guarded width against `originalWidth` but never guarded height against `originalHeight` — same class of bug.
- **Fixed crop-alias aspect-ratio maths:** the main path computed `height = cropHeight / cropWidth * width` using integer division, truncating to `0` for any landscape crop and corrupting the `aspect-ratio` style. It now uses `StringUtils.GetDouble(...)`, matching the responsive `<source>` code.
- **Removed dead code:** the `sourceHeight` local in both `<source>` loops was assigned but never read.

## Notes for reviewer

- When a dimension already fits within the source, behaviour is unchanged (`scale` stays `1`).
- The `src`/`FileSource` (non-media) path is intentionally untouched: original dimensions are unknowable for an external/disk URL, so upscaling can't be prevented there.